### PR TITLE
reorg: ne pas charger la lib d'accès API dans le parseur

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,6 +1,6 @@
 module Main where
 
-import           TwitchParser         (fetchViewerCount)
+import           TwitchAPI    (fetchViewerCount)
 
 main :: IO ()
 main = do

--- a/src/TwitchAPI.hs
+++ b/src/TwitchAPI.hs
@@ -3,9 +3,10 @@
 {-# LANGUAGE TypeOperators     #-}
 
 module TwitchAPI
-  ( fetchMetadatas
+  ( fetchViewerCount
   ) where
 
+import           TwitchParser (interpretMetadatas)
 import           Types
 
 import           Data.Proxy              (Proxy (..))
@@ -42,6 +43,9 @@ fetchMetadatas userLogin = do
       clientEnv = ClientEnv manager baseUrl
   result <- runClientM fetchClient clientEnv
   pure (convertError result)
+
+fetchViewerCount :: UserLogin -> IO (Maybe Int)
+fetchViewerCount userLogin = interpretMetadatas <$> fetchMetadatas userLogin
 
 convertError :: Either ServantError Metadatas -> Either String Metadatas
 convertError (Left err)     = Left (serializeError err)

--- a/src/TwitchParser.hs
+++ b/src/TwitchParser.hs
@@ -1,16 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module TwitchParser
-    ( fetchViewerCount
-    , interpretMetadatas
+    ( interpretMetadatas
     ) where
 
 import           Types
-
-import           TwitchAPI (fetchMetadatas)
-
-fetchViewerCount :: UserLogin -> IO (Maybe Int)
-fetchViewerCount userLogin = interpretMetadatas <$> fetchMetadatas userLogin
 
 interpretMetadatas :: Either String Metadatas -> Maybe Int
 interpretMetadatas (Left   _)     = Nothing


### PR DESCRIPTION
Pas grand chose en tête pour l'instant. 

Par contre mieux séparer les responsabilités API / Parser me parait intéressant, d'où la PR.